### PR TITLE
Fix typos in grafi

### DIFF
--- a/biokeminfo/osnove/grafi.md
+++ b/biokeminfo/osnove/grafi.md
@@ -1,8 +1,8 @@
 # Grafi v molekularni biologiji
 
-Najbolj splošna definicija grafa (s področja diskretne matematike) je *množica točk in povezav med njimi* ([Wikipedia](https://en.wikipedia.org/wiki/Graph_(discrete_mathematics))), podrobno ga pa obravnava *teorija grafov* ([Wikipedia](https://en.wikipedia.org/wiki/Graph_theory)). Grafi so zelo uporaben način predstavitve in povezave nekih objektov ter povezav med njimi. V biologiji, biokemiji, molekularni biologiji ... jih pogosto uporabljamo za predstavitev odnosom ved organizmi, prikaz medproteinskih ali drugih medmolekulskih interakcij, regulatornih povezav ipd.
+Najbolj splošna definicija grafa (s področja diskretne matematike) je *množica točk in povezav med njimi* ([Wikipedia](https://en.wikipedia.org/wiki/Graph_(discrete_mathematics))), podrobno ga pa obravnava *teorija grafov* ([Wikipedia](https://en.wikipedia.org/wiki/Graph_theory)). Grafi so zelo uporaben način predstavitve in povezave nekih objektov ter povezav med njimi. V biologiji, biokemiji, molekularni biologiji ... jih pogosto uporabljamo za predstavitev odnosov ved organizmi, prikaz medproteinskih ali drugih medmolekulskih interakcij, regulatornih povezav ipd.
 
-Medproteinske interakcije so, na primer, zbrane v zbirki [STRING](https://string-db.org/), kjer si jih lahko ogledamo na grafičen način - kot grafe. Primer prikazan medproteinskih interakcij človepkega proteina p53 je prikazan spodaj (različne barve povezav med proteini ponazarjajo status interakcije - eksperimentalno potrjene ali napovedane interakcije).
+Medproteinske interakcije so, na primer, zbrane v zbirki [STRING](https://string-db.org/), kjer si jih lahko ogledamo na grafičen način – kot grafe. Primer medproteinskih interakcij človeškega proteina p53 je prikazan spodaj (različne barve povezav med proteini ponazarjajo status interakcije – eksperimentalno potrjene ali napovedane interakcije).
 
 ![Primer interakcij p53 iz zbirke STRING](slike/string_p53_primer.png)
 

--- a/biokeminfo/osnove/grafi.md
+++ b/biokeminfo/osnove/grafi.md
@@ -1,6 +1,6 @@
 # Grafi v molekularni biologiji
 
-Najbolj splošna definicija grafa (s področja diskretne matematike) je *množica točk in povezav med njimi* ([Wikipedia](https://en.wikipedia.org/wiki/Graph_(discrete_mathematics))), podrobno ga pa obravnava *teorija grafov* ([Wikipedia](https://en.wikipedia.org/wiki/Graph_theory)). Grafi so zelo uporaben način predstavitve in povezave nekih objektov ter povezav med njimi. V biologiji, biokemiji, molekularni biologiji ... jih pogosto uporabljamo za predstavitev odnosov ved organizmi, prikaz medproteinskih ali drugih medmolekulskih interakcij, regulatornih povezav ipd.
+Najbolj splošna definicija grafa (s področja diskretne matematike) je *množica točk in povezav med njimi* ([Wikipedia](https://en.wikipedia.org/wiki/Graph_(discrete_mathematics))), podrobno ga pa obravnava *teorija grafov* ([Wikipedia](https://en.wikipedia.org/wiki/Graph_theory)). Grafi so zelo uporaben način predstavitve in povezave nekih objektov ter povezav med njimi. V biologiji, biokemiji, molekularni biologiji ... jih pogosto uporabljamo za predstavitev odnosov med organizmi, prikaz medproteinskih ali drugih medmolekulskih interakcij, regulatornih povezav ipd.
 
 Medproteinske interakcije so, na primer, zbrane v zbirki [STRING](https://string-db.org/), kjer si jih lahko ogledamo na grafičen način – kot grafe. Primer medproteinskih interakcij človeškega proteina p53 je prikazan spodaj (različne barve povezav med proteini ponazarjajo status interakcije – eksperimentalno potrjene ali napovedane interakcije).
 


### PR DESCRIPTION
Ta PR popravi tipkarske palčke v poglavju _Grafi v molekularni biologiji_